### PR TITLE
Added ability to define alphabet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Laravel Public ID
 
-A simple and (almost) automatic short ids (like youtube ids) generator for your laravel projects. Powered by Hashids project (and malahierba dev team)
+A simple and automatic short ids (like youtube ids) generator for your laravel projects. Powered by Hashids project (and malahierba dev team)
 
 ## Installation
 
@@ -50,7 +50,7 @@ After that, you can setup the static variables to define the settings for the pu
     	
     	//your code...
 
-There are 4 predefined alphabets you can use.  Setting the `public_id_alphabet` variable to 'upper_alphanumeric', 'upper_alpha', 'lower_alphanumeric', 'lower_alpha' will use those predefined alphabets:
+There are 4 predefined alphabets you can use.  Setting the `public_id_alphabet` variable to `upper_alphanumeric`, `upper_alpha`, `lower_alphanumeric`, `lower_alpha` will use those predefined alphabets:
 
     upper_alphanumeric => ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
     upper_alpha => ABCDEFGHIJKLMNOPQRSTUVWXYZ

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Example for Post Model:
     	
     	//your code...
 
-After that, you need setup two static and protected variables: `public_id_salt` and `public_id_min_length`, in previous example:
+After that, you can setup the static variables to define the settings for the publicID: `public_id_salt`, `public_id_min_length`, `public_id_alphabet`, in previous example:
 
     <?php namespace App;
 
@@ -45,8 +45,17 @@ After that, you need setup two static and protected variables: `public_id_salt` 
     	static protected $public_id_salt = 'some_string_for_salt_your_ids';
 
         static protected $public_id_min_length = 6; // min length for your generated short ids.
+        
+        static protected $public_id_alphabet = 'ABCDEFGHIJKLM'; // Only letters A-M
     	
     	//your code...
+
+There are 4 predefined alphabets you can use.  Setting the `public_id_alphabet` variable to 'upper_alphanumeric', 'upper_alpha', 'lower_alphanumeric', 'lower_alpha' will use those predefined alphabets:
+
+    upper_alphanumeric => ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
+    upper_alpha => ABCDEFGHIJKLMNOPQRSTUVWXYZ
+    lower_alphanumeric => abcdefghijklmnopqrstuvwxyz0123456789
+    lower_alpha => abcdefghijklmnopqrstuvwxyz
 
 That's all. Now you can use the Public ID functionality in your Post Model:
 

--- a/src/PublicId.php
+++ b/src/PublicId.php
@@ -15,7 +15,7 @@ trait PublicId {
      */
     static public function publicIdDecode($public_id)
     {
-        $hashids = new Hashids(self::$public_id_salt, self::$public_id_min_length);
+        $hashids = new Hashids(self::getSalt(), self::getMinLength(), self::getAlphabet());
 
         $id = $hashids->decode($public_id);
 

--- a/src/PublicId.php
+++ b/src/PublicId.php
@@ -36,7 +36,7 @@ trait PublicId {
      */
     public function getPublicIdAttribute()
     {
-        $hashids = new Hashids(self::$public_id_salt, self::$public_id_min_length);
+        $hashids = new Hashids(self::getSalt(), self::getMinLength(), self::getAlphabet());
 
         $primaryKey = $this->primaryKey;
 
@@ -68,8 +68,61 @@ trait PublicId {
      */
     static public function testPublicIdMaxInt()
     {
-        $hashids = new Hashids(self::$public_id_salt, self::$public_id_min_length);
+        $hashids = new Hashids(self::getSalt(), self::getMinLength(), self::getAlphabet());
 
         return $hashids->get_max_int_value();
+    }
+
+    /**
+     * Get the alphabet property, if it's set by the user.
+     *
+     * @access private
+     * @return string
+     */
+    static private function getAlphabet(){
+        if(property_exists(self::class, 'public_id_alphabet')){
+            switch(self::$public_id_alphabet){
+                case 'upper_alphanumeric':
+                    return "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+                case 'upper_alpha':
+                    return "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+                case 'lower_alphanumeric':
+                    return "abcdefghijklmnopqrstuvwxyz0123456789";
+                case 'lower_alpha':
+                    return "abcdefghijklmnopqrstuvwxyz";
+                default:
+                    return self::$public_id_alphabet;
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * Get the salt property, if the user has set it.
+     *
+     * @access private
+     * @return string
+     */
+    static private function getSalt(){
+        if(property_exists(self::class, 'public_id_salt')){
+            return self::$public_id_salt;
+        }
+
+        return '';
+    }
+
+    /**
+     * Get the min length property, if the user has set it.
+     *
+     * @access private
+     * @return integer
+     */
+    static private function getMinLength(){
+        if(property_exists(self::class, 'public_id_min_length')){
+            return self::$public_id_min_length;
+        }
+
+        return 0;
     }
 }


### PR DESCRIPTION
In this patch I have:
- Added the ability to define (and use) the public_id_alphabet property
- Defined 4 pre-set alphabets (upper/lower alpha/alphanumeric)
- Introduced accessor methods to retrieve the properties
  - This has the added benefit of preventing the trait falling over when the user doesn't define the properties
  - This also allows users to get started far quicker.
